### PR TITLE
Tasty now uses "." for namespaces instead of "/"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,9 @@ addons:
 # change flags or use --stack-yaml to point to a different file.
 env:
 - ARGS=""
-- ARGS="--resolver lts-6"
-- ARGS="--resolver lts-5"
-- ARGS="--resolver lts-4"
-- ARGS="--resolver lts-3"
-- ARGS="--resolver lts-2"
+- ARGS="--resolver lts-14"
+- ARGS="--resolver lts-13"
+- ARGS="--resolver lts-12"
 - ARGS="--resolver nightly"
 
 before_install:

--- a/src/Test/Tasty/Runners/TAP.hs
+++ b/src/Test/Tasty/Runners/TAP.hs
@@ -13,7 +13,6 @@ import           Control.Monad
 import qualified Data.IntMap.Strict     as IM
 import           Data.List
 import           Data.Maybe
-import           Data.Monoid
 import           System.IO
 import           Test.Tasty.Ingredients
 import           Test.Tasty.Options

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.0
+resolver: lts-14.12
 packages:
 - '.'
 extra-deps: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-7.14
+resolver: lts-12.0
 packages:
 - '.'
 extra-deps: []

--- a/tasty-tap.cabal
+++ b/tasty-tap.cabal
@@ -28,7 +28,7 @@ flag lib-Werror
 library
   exposed-modules:     Test.Tasty.Runners.TAP
   build-depends:       base >=4.6 && <5
-                     , tasty >= 0.10
+                     , tasty >= 1.1
                      , stm
                      , containers
   hs-source-dirs:      src
@@ -47,7 +47,7 @@ test-suite test
   default-language:   Haskell2010
 
   build-depends:    base
-                  , tasty
+                  , tasty >= 1.1
                   , tasty-tap
                   , tasty-hunit
                   , tasty-golden

--- a/test/golden/simple.tap
+++ b/test/golden/simple.tap
@@ -1,5 +1,6 @@
 TAP version 13
 1..2
-ok 1 - some example tests/passes
-not ok 2 - some example tests/fails
+ok 1 - some example tests.passes
+not ok 2 - some example tests.fails
+# test/Main.hs:56:
 # this was doomed


### PR DESCRIPTION
- Tasty now uses "." for namespaces instead of "/".
- Update the golden test appropriately.
- Add new location information for test failures.

Fixes issue #2.